### PR TITLE
C468 User access

### DIFF
--- a/aws/main.go
+++ b/aws/main.go
@@ -8,8 +8,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/lib/pq"
 	"github.com/nullstone-modules/pg-db-admin/postgresql"
+	"net/url"
 	"os"
+	"strings"
 )
 
 const (
@@ -48,6 +51,7 @@ func ensureDatabase(ctx context.Context, metadata map[string]string) error {
 	if newDatabase.Name == "" {
 		return fmt.Errorf("cannot create database: databaseName is required")
 	}
+	newDatabase.Owner = newDatabase.Name
 
 	db, err := getMaintenanceDb(ctx)
 	if err != nil {
@@ -61,11 +65,9 @@ func ensureDatabase(ctx context.Context, metadata map[string]string) error {
 	}
 
 	// Create a role with the same name as the database to give ownership
-	ownerRole := postgresql.Role{Name: newDatabase.Name}
-	if err := ownerRole.Ensure(db); err != nil {
+	if err := (postgresql.Role{Name: newDatabase.Name}).Ensure(db); err != nil {
 		return fmt.Errorf("error ensuring database owner role: %w", err)
 	}
-	newDatabase.Owner = ownerRole.Name
 
 	return newDatabase.Ensure(db, *dbInfo)
 }
@@ -116,7 +118,31 @@ func grantUserDbAccess(ctx context.Context, metadata map[string]string) error {
 		Member: user.Name,
 		Target: database.Owner,
 	}
-	return newRoleGrant.Ensure(db)
+	if err := newRoleGrant.Ensure(db); err != nil {
+		return fmt.Errorf("error granting")
+	}
+
+	return grantAllPrivileges(ctx, database, user)
+}
+
+func grantAllPrivileges(ctx context.Context, database postgresql.Database, user postgresql.Role) error {
+	db, err := getAppDb(ctx, database.Name)
+	if err != nil {
+		return fmt.Errorf("error connecting to postgres: %w", err)
+	}
+	defer db.Close()
+
+	sq := strings.Join([]string{
+		// CREATE | USAGE
+		fmt.Sprintf(`GRANT ALL PRIVILEGES ON SCHEMA public TO %q;`, pq.QuoteIdentifier(user.Name)),
+		// CREATE | CONNECT | TEMPORARY | TEMP
+		fmt.Sprintf(`GRANT ALL PRIVILEGES ON DATABASE %q TO %q;`, pq.QuoteIdentifier(database.Name), pq.QuoteIdentifier(user.Name)),
+	}, " ")
+
+	if _, err := db.Exec(sq); err != nil {
+		return fmt.Errorf("error granting privileges: %w", err)
+	}
+	return nil
 }
 
 func getMaintenanceDb(ctx context.Context) (*sql.DB, error) {
@@ -126,6 +152,21 @@ func getMaintenanceDb(ctx context.Context) (*sql.DB, error) {
 	}
 
 	return sql.Open("postgres", connUrl)
+}
+
+func getAppDb(ctx context.Context, databaseName string) (*sql.DB, error) {
+	connUrl, err := getConnectionUrl(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving postgres connection url: %w", err)
+	}
+
+	u, err := url.Parse(connUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid connection url %q: %w", connUrl, err)
+	}
+	u.Path = fmt.Sprintf("/%s", url.PathEscape(databaseName))
+
+	return sql.Open("postgres", u.String())
 }
 
 func getConnectionUrl(ctx context.Context) (string, error) {


### PR DESCRIPTION
This PR adds `CREATE`, `USAGE` privileges to the `public` schema and `CREATE`, `CONNECT`, `TEMP` privileges to the database.
This is in addition to granting access to the role that owns the database which already has access to the schema.