### PR TITLE
F1862 lambda runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ tools:
 
 build:
 	mkdir -p ./aws/tf/files
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./aws/tf/files/pg-db-admin ./aws/
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o ./aws/tf/files/bootstrap ./aws/
 	# Run build on gcp to ensure a successful build, we discard it
 	GOOS=linux GOARCH=amd64 go build -o ./gcp/tf/files/pg-db-admin ./gcp/; rm -f ./gcp/tf/files/pg-db-admin
 
 package: tools
 	# Package aws module using build-lambda-zip which produces a viable package from any OS
-	cd ./aws/tf && build-lambda-zip --output files/pg-db-admin.zip files/pg-db-admin
+	cd ./aws/tf && build-lambda-zip --output files/pg-db-admin.zip files/bootstrap
 	# Package gcp module (source code instead of binary)
 	# For GCP, main.go *must* be in the root of the zip file
 	cp gcp/main.go main.go && \

--- a/aws/tf/lambda.tf
+++ b/aws/tf/lambda.tf
@@ -2,8 +2,8 @@ resource "aws_lambda_function" "db_admin" {
   function_name    = var.name
   tags             = var.tags
   role             = aws_iam_role.db_admin.arn
-  runtime          = "go1.x"
-  handler          = "pg-db-admin"
+  runtime          = "provided.al2023"
+  handler          = "bootstrap"
   filename         = "${path.module}/files/pg-db-admin.zip"
   source_code_hash = filebase64sha256("${path.module}/files/pg-db-admin.zip")
   // This can take ~5s to create a db sometimes

--- a/aws/tf/setup.tf
+++ b/aws/tf/setup.tf
@@ -2,8 +2,8 @@ resource "aws_lambda_function" "db_admin_setup" {
   function_name    = "${var.name}-setup"
   tags             = var.tags
   role             = aws_iam_role.db_admin.arn
-  runtime          = "go1.x"
-  handler          = "pg-db-admin"
+  runtime          = "provided.al2023"
+  handler          = "bootstrap"
   filename         = "${path.module}/files/pg-db-admin.zip"
   source_code_hash = filebase64sha256("${path.module}/files/pg-db-admin.zip")
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.7.4
-	github.com/aws/aws-lambda-go v1.34.1
+	github.com/aws/aws-lambda-go v1.46.0
 	github.com/aws/aws-sdk-go-v2 v1.7.1
 	github.com/aws/aws-sdk-go-v2/config v1.5.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -598,8 +598,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/aws/aws-lambda-go v1.34.1 h1:M3a/uFYBjii+tDcOJ0wL/WyFi2550FHoECdPf27zvOs=
-github.com/aws/aws-lambda-go v1.34.1/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
+github.com/aws/aws-lambda-go v1.46.0 h1:UWVnvh2h2gecOlFhHQfIPQcD8pL/f7pVCutmFl+oXU8=
+github.com/aws/aws-lambda-go v1.46.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.7.1 h1:TswSc7KNqZ/K1Ijt3IkpXk/2+62vi3Q82Yrr5wSbRBQ=
 github.com/aws/aws-sdk-go-v2 v1.7.1/go.mod h1:L5LuPC1ZgDr2xQS7AmIec/Jlc7O/Y1u2KxJyNVab250=
 github.com/aws/aws-sdk-go-v2/config v1.5.0 h1:tRQcWXVmO7wC+ApwYc2LiYKfIBoIrdzcJ+7HIh6AlR0=


### PR DESCRIPTION
update this admin to use provided.al2023 runtime instead of the deprecated go1.x runtime